### PR TITLE
[tvOS] Bring back memphiz siri remote settings + setting to choose between Kodi or tvOS keyboard

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15527,7 +15527,61 @@ msgctxt "#24152"
 msgid "The add-on is not compatible with this version of Kodi."
 msgstr ""
 
-#empty strings from id 24153 to 24990
+#: apple remote
+msgctxt "#24153"
+msgid "Enable to make the Siri remote match the normal Apple tvOS behavior"
+msgstr ""
+
+#: apple remote
+msgctxt "#24154"
+msgid "Idle remote handling after N seconds"
+msgstr ""
+
+#: apple remote
+msgctxt "#24155"
+msgid "After remote idles, the first tap/swipe received will wake it"
+msgstr ""
+
+#: apple remote
+msgctxt "#24156"
+msgid "30 Seconds"
+msgstr ""
+
+#: apple remote
+msgctxt "#24157"
+msgid "60 Seconds"
+msgstr ""
+
+#: apple remote
+msgctxt "#24158"
+msgid "90 Seconds"
+msgstr ""
+
+#: apple remote
+msgctxt "#24159"
+msgid "120 Seconds"
+msgstr ""
+
+#: apple remote
+msgctxt "#24160"
+msgid "Enable Siri remote timeout"
+msgstr ""
+
+#: apple remote
+msgctxt "#24161"
+msgid "Enable remote input timeout for tap/swipe"
+msgstr ""
+
+msgctxt "#24162"
+msgid "Use Kodi virtual keyboard"
+msgstr ""
+
+#: apple remote
+msgctxt "#24163"
+msgid "Match Apple tvOS Standard (Siri remote)"
+msgstr ""
+
+#empty strings from id 24164 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -8,63 +8,72 @@
           <default></default>
         </setting>
         <setting id="screensaver.usemusicvisinstead">
-            <default>false</default>
+          <default>false</default>
         </setting>
         <setting id="screensaver.usedimonpause">
-            <default>false</default>
+          <default>false</default>
         </setting>
       </group>
     </category>
     <category id="masterlock">
-        <visible>false</visible>
+      <visible>false</visible>
     </category>
-    <category id="control">
-        <group id="1">
-            <setting id="input.peripherals">
-                <visible>false</visible>
-            </setting>
-        </group>
-        <group id="2">
-            <setting id="input.enablemouse">
-                <default>false</default>
-                <visible>false</visible>
-            </setting>
-            <setting id="input.controllerconfig">
-                <visible>false</visible>
-            </setting>
-            <setting id="input.appleremotemode">
-                <visible>false</visible>
-            </setting>
-            <setting id="input.appleremotesequencetime">
-                <visible>false</visible>
-            </setting>
-            <setting id="input.applesiri" type="boolean" label="24152" help="24153">
-                <level>1</level>
-                <default>false</default>
-                <control type="toggle" />
-            </setting>
-            <setting id="input.applesiritimeoutenabled" type="boolean" label="24160" help="24161">
-                <level>1</level>
-                <default>true</default>
-                <control type="toggle" />
-            </setting>
-            <setting id="input.applesiritimeout" type="integer" label="24154" help="24155">
-                <level>1</level>
-                <default>60</default>
-                <constraints>
-                    <options>
-                        <option label="24156">30</option>
-                        <option label="24157">60</option>
-                        <option label="24158">90</option>
-                        <option label="24159">120</option>
-                    </options>
-                </constraints>
-                <control type="list" format="integer" />
-                <dependencies>
-                    <dependency type="enable" setting="input.applesiritimeoutenabled">true</dependency>
-                </dependencies>
-            </setting>
-        </group>
+  </section>
+  <section id="system">
+    <category id="input">
+      <group id="1">
+        <setting id="input.peripherals">
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="2">
+        <setting id="input.enablemouse">
+          <default>false</default>
+          <visible>false</visible>
+        </setting>
+        <setting id="input.controllerconfig">
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="3">
+        <setting id="input.appleremotemode">
+          <visible>false</visible>
+        </setting>
+        <setting id="input.appleremotesequencetime">
+          <visible>false</visible>
+        </setting>
+        <setting id="input.applesiri" type="boolean" label="24163" help="24153">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="input.applesiritimeoutenabled" type="boolean" label="24160" help="24161">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="input.applesiritimeout" type="integer" label="24154" help="24155">
+          <level>1</level>
+          <default>60</default>
+          <constraints>
+            <options>
+              <option label="24156">30</option>
+              <option label="24157">60</option>
+              <option label="24158">90</option>
+              <option label="24159">120</option>
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+          <dependencies>
+            <dependency type="enable" setting="input.applesiritimeoutenabled">true</dependency>
+          </dependencies>
+        </setting>
+        <setting id="input.appleusekodikeyboard" type="boolean" label="24162">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
   </section>
   <section id="player">
@@ -118,9 +127,9 @@
       </group>
     </category>
     <category id="powermanagement">
-        <group id="1">
-            <visible>false</visible>
-        </group>
+      <group id="1">
+        <visible>false</visible>
+      </group>
     </category>
   </section>
 </settings>

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -84,7 +84,18 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, CVariant hea
     headingStr = g_localizeStrings.Get((uint32_t)heading.asInteger());
 
 #if defined(TARGET_DARWIN_EMBEDDED)
-  kb = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardTouch>(WINDOW_DIALOG_KEYBOARD_TOUCH);
+  bool use_kodi_keyboard = false;
+  #if defined(TARGET_DARWIN_TVOS)
+  use_kodi_keyboard = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_INPUT_APPLEUSEKODIKEYBOARD);
+  #endif
+  if(use_kodi_keyboard)
+  {
+    kb = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardGeneric>(WINDOW_DIALOG_KEYBOARD);
+  }
+  else
+  {
+    kb = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardTouch>(WINDOW_DIALOG_KEYBOARD_TOUCH);
+  }
 #else
   kb = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardGeneric>(WINDOW_DIALOG_KEYBOARD);
 #endif

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -373,6 +373,7 @@ const std::string CSettings::SETTING_INPUT_APPLEREMOTESEQUENCETIME = "input.appl
 const std::string CSettings::SETTING_INPUT_APPLESIRI = "input.applesiri";
 const std::string CSettings::SETTING_INPUT_APPLESIRITIMEOUT = "input.applesiritimeout";
 const std::string CSettings::SETTING_INPUT_APPLESIRITIMEOUTENABLED = "input.applesiritimeoutenabled";
+const std::string CSettings::SETTING_INPUT_APPLEUSEKODIKEYBOARD = "input.appleusekodikeyboard";
 const std::string CSettings::SETTING_NETWORK_USEHTTPPROXY = "network.usehttpproxy";
 const std::string CSettings::SETTING_NETWORK_HTTPPROXYTYPE = "network.httpproxytype";
 const std::string CSettings::SETTING_NETWORK_HTTPPROXYSERVER = "network.httpproxyserver";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -333,6 +333,7 @@ public:
   static const std::string SETTING_INPUT_APPLESIRI;
   static const std::string SETTING_INPUT_APPLESIRITIMEOUT;
   static const std::string SETTING_INPUT_APPLESIRITIMEOUTENABLED;
+  static const std::string SETTING_INPUT_APPLEUSEKODIKEYBOARD;
   static const std::string SETTING_NETWORK_USEHTTPPROXY;
   static const std::string SETTING_NETWORK_HTTPPROXYTYPE;
   static const std::string SETTING_NETWORK_HTTPPROXYSERVER;


### PR DESCRIPTION
* Bring back settings present in yab branch
* Add setting to choose between Kodi or tvOS keyboard